### PR TITLE
10 add vega tradingdata client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Python SDK
+# Vega Python SDK
 
-Version: 0.44.0
+Version: 0.47.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-VERSION = "0.44.0"
+VERSION = "0.47.0"
 
 setuptools.setup(
     name="Vega API client",

--- a/vegaapiclient/__init__.py
+++ b/vegaapiclient/__init__.py
@@ -2,6 +2,7 @@ from .generated import data_node, github, vega
 from .helpers import grpc_error_detail
 from .vegacoreclient import VegaCoreClient
 from .vegacorestateclient import VegaCoreStateClient
+from .vegatradingdataclient import VegaTradingDataClient
 
 __all__ = [
     "data_node",
@@ -10,4 +11,5 @@ __all__ = [
     "grpc_error_detail",
     "VegaCoreClient",
     "VegaCoreStateClient",
+    "VegaTradingDataClient",
 ]

--- a/vegaapiclient/vegatradingdataclient.py
+++ b/vegaapiclient/vegatradingdataclient.py
@@ -1,0 +1,15 @@
+from .generated.data_node.api.v1 import trading_data_grpc
+from .grpcclient import GRPCClient
+
+
+class VegaTradingDataClient(GRPCClient):
+    """
+    The Vega Core State Client talks to a back-end node.
+    """
+
+    def __init__(self, url: str, channel=None) -> None:
+        super().__init__(url, channel=channel)
+        self._corestate = trading_data_grpc.TradingDataServiceStub(self.channel)
+
+    def __getattr__(self, funcname):
+        return getattr(self._corestate, funcname)

--- a/vegaapiclient/vegatradingdataclient.py
+++ b/vegaapiclient/vegatradingdataclient.py
@@ -4,7 +4,7 @@ from .grpcclient import GRPCClient
 
 class VegaTradingDataClient(GRPCClient):
     """
-    The Vega Core State Client talks to a back-end node.
+    The Vega Trading Data Client talks to a back-end node.
     """
 
     def __init__(self, url: str, channel=None) -> None:

--- a/vegaapiclient/vegatradingdataclient.py
+++ b/vegaapiclient/vegatradingdataclient.py
@@ -9,7 +9,9 @@ class VegaTradingDataClient(GRPCClient):
 
     def __init__(self, url: str, channel=None) -> None:
         super().__init__(url, channel=channel)
-        self._corestate = trading_data_grpc.TradingDataServiceStub(self.channel)
+        self._tradingdata = trading_data_grpc.TradingDataServiceStub(
+            self.channel
+        )
 
     def __getattr__(self, funcname):
-        return getattr(self._corestate, funcname)
+        return getattr(self._tradingdata, funcname)


### PR DESCRIPTION
closes #10 

I've pip installed this locally and used `VegaTradingDataClient` to make a call into the data-node by doing `MarketDataByID` and all is good.

In terms of the bumping the actual python-packge to `0.47.0`, locally `pip show` returns:
```
Name: Vega-API-client
Version: 0.47.0
Summary: Vega API client for gRPC
Home-page: https://github.com/vegaprotocol/api
Author: Vega
Author-email: hi@vega.xyz
License: UNKNOWN
Location: /Users/wwestgarth/work/sdk-python
Requires: googleapis-common-protos, grpcio, requests
Required-by:
```
but unfortunately the github action to push to PyPi is triggered on setting a tag, and the repo has already been tagged at `0.47.0` so a retag might be in order.